### PR TITLE
:rocket: rabbitmq management configs added

### DIFF
--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.9'
-
 services:
 
   postgres:
@@ -32,14 +30,21 @@ services:
     command: redis-server
 
   rabbitmq:
+    image: rabbitmq:3.12-management
     container_name: rabbitmq
-    image: rabbitmq:3.9-management-alpine
-    environment:
-      RABBITMQ_DEFAULT_USER: "admin"
-      RABBITMQ_DEFAULT_PASS: "admin"
+    restart: unless-stopped
     ports:
       - "5672:5672"
       - "15672:15672"
+    environment:
+      RABBITMQ_DEFAULT_USER: "${RABBITMQ_USERNAME:-root}"
+      RABBITMQ_DEFAULT_PASS: "${RABBITMQ_PASSWORD:-root}"
+    command: >
+      sh -c "rabbitmq-plugins enable --offline \
+      rabbitmq_amqp1_0 rabbitmq_management rabbitmq_web_dispatch rabbitmq_management_agent rabbitmq_stomp && \
+      exec rabbitmq-server"
+    volumes:
+      - "./rabbitmq-config:/etc/rabbitmq"
 
   jaeger:
     container_name: jaeger

--- a/infra/rabbitmq-config/enabled_plugins
+++ b/infra/rabbitmq-config/enabled_plugins
@@ -1,0 +1,1 @@
+[rabbitmq_amqp1_0,rabbitmq_management,rabbitmq_management_agent,rabbitmq_stomp,rabbitmq_web_dispatch].

--- a/infra/rabbitmq-config/management_agent.disable_metrics_collector.conf 
+++ b/infra/rabbitmq-config/management_agent.disable_metrics_collector.conf 
@@ -1,0 +1,1 @@
+management_agent.disable_metrics_collector = false


### PR DESCRIPTION
```
Effect of This Configuration

1. Enables multiple protocols (AMQP 1.0, STOMP).
2. Activates RabbitMQ's web-based management UI.
3. Ensures that metrics collection remains enabled, allowing monitoring and performance insights.
```

Note: `Starting from Docker Compose v2.0, the version field is deprecated and no longer required. Docker will automatically use the latest schema version supported by your installed Compose.`